### PR TITLE
Switches to eprintln! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ extern crate rayon;
 extern crate fnv;
 
 use std::io;
-#[cfg(feature = "debug-stderr")] use std::io::Write;
 use std::{error, fmt, f32};
 use std::borrow::Cow;
 use std::path::Path;
@@ -23,8 +22,6 @@ use color_quant::NeuQuant;
 use lab::Lab;
 use rayon::prelude::*;
 use fnv::FnvHashMap;
-
-#[cfg(feature = "debug-stderr")] #[macro_use] mod macros;
 
 #[cfg(feature = "debug-stderr")] use std::time::{Instant};
 
@@ -258,7 +255,7 @@ pub fn engiffen(imgs: &[Image], fps: usize, quantizer: Quantizer) -> Result<Gif,
     if imgs.is_empty() {
         return Err(Error::NoImages);
     }
-    #[cfg(feature = "debug-stderr")] printerr!("Engiffening {} images", imgs.len());
+    #[cfg(feature = "debug-stderr")] eprintln!("Engiffening {} images", imgs.len());
 
     let (width, height) = {
         let ref first = imgs[0];
@@ -316,12 +313,12 @@ fn neuquant_palettize(imgs: &[Image], sample_rate: u32, width: u32, height: u32)
         acc
     });
     #[cfg(feature = "debug-stderr")]
-    printerr!("Neuquant: Concatenated {} bytes in {} ms.", colors.len(), ms(time_push));
+    eprintln!("Neuquant: Concatenated {} bytes in {} ms.", colors.len(), ms(time_push));
 
     #[cfg(feature = "debug-stderr")] let time_quant = Instant::now();
     let quant = NeuQuant::new(10, 256, &colors);
     #[cfg(feature = "debug-stderr")]
-    printerr!("Neuquant: Computed palette in {} ms.", ms(time_quant));
+    eprintln!("Neuquant: Computed palette in {} ms.", ms(time_quant));
 
     #[cfg(feature = "debug-stderr")] let time_map = Instant::now();
     let mut transparency = None;
@@ -338,7 +335,7 @@ fn neuquant_palettize(imgs: &[Image], sample_rate: u32, width: u32, height: u32)
         }).collect()
     }).collect();
     #[cfg(feature = "debug-stderr")]
-    printerr!("Neuquant: Mapped pixels to palette in {} ms.", ms(time_map));
+    eprintln!("Neuquant: Mapped pixels to palette in {} ms.", ms(time_map));
 
     (quant.color_map_rgb(), palettized_imgs, transparency)
 }
@@ -360,7 +357,7 @@ fn naive_palettize(imgs: &[Image]) -> (Vec<u8>, Vec<Vec<u8>>, Option<u8>) {
         acc
     });
     #[cfg(feature = "debug-stderr")]
-    printerr!("Naive: Counted color frequencies in {} ms", ms(time_count));
+    eprintln!("Naive: Counted color frequencies in {} ms", ms(time_count));
     #[cfg(feature = "debug-stderr")] let time_palette = Instant::now();
     let mut sorted_frequencies = frequencies.into_iter()
         .collect::<Vec<_>>();
@@ -393,7 +390,7 @@ fn naive_palettize(imgs: &[Image]) -> (Vec<u8>, Vec<Vec<u8>>, Option<u8>) {
         map.insert(color.0, index);
     }
     #[cfg(feature = "debug-stderr")]
-    printerr!("Naive: Computed palette in {} ms.", ms(time_palette));
+    eprintln!("Naive: Computed palette in {} ms.", ms(time_palette));
 
     #[cfg(feature = "debug-stderr")]let time_index = Instant::now();
     let palettized_imgs: Vec<Vec<u8>> = imgs.par_iter().map(|img| {
@@ -402,7 +399,7 @@ fn naive_palettize(imgs: &[Image]) -> (Vec<u8>, Vec<Vec<u8>>, Option<u8>) {
         }).collect()
     }).collect();
     #[cfg(feature = "debug-stderr")]
-    printerr!("Naive: Mapped pixels to palette in {} ms", ms(time_index));
+    eprintln!("Naive: Mapped pixels to palette in {} ms", ms(time_index));
 
     let mut palette_as_bytes = Vec::with_capacity(palette.len() * 3);
     for color in palette {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,0 @@
-macro_rules! printerr {
-    ($($arg:tt)*) => (writeln!(&mut std::io::stderr(), $($arg)*).expect("failed to write to stderr"));
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ extern crate getopts;
 extern crate rand;
 #[cfg(feature = "globbing")] extern crate glob;
 
-use std::io::{self, Write, BufWriter};
+use std::io::{self, BufWriter};
 use std::{env, fmt, process};
 use std::fs::{read_dir, File};
 use std::path::PathBuf;
@@ -16,7 +16,6 @@ use parse_args::{parse_args, Args, SourceImages, Modifier};
 use rand::distributions::exponential::Exp1;
 use rand::distributions::{IndependentSample, Range};
 
-#[macro_use] mod macros;
 mod parse_args;
 
 #[derive(Debug)]
@@ -69,7 +68,7 @@ fn run_engiffen(args: &Args) -> Result<((Option<String>, Duration)), RuntimeErro
                 .filter_map(std::result::Result::ok)
                 .collect();
             #[cfg(feature = "debug-stderr")]
-            printerr!("Expanded {} into {} files.", string, paths.len());
+            eprintln!("Expanded {} into {} files.", string, paths.len());
             paths
         },
     };
@@ -101,7 +100,7 @@ fn run_engiffen(args: &Args) -> Result<((Option<String>, Duration)), RuntimeErro
 fn main() {
     let arg_strings: Vec<String> = env::args().collect();
     let args = parse_args(&arg_strings).map_err(|e| {
-        printerr!("{}", e);
+        eprintln!("{}", e);
         process::exit(1);
     }).unwrap();
 
@@ -109,10 +108,10 @@ fn main() {
         Ok((file, duration)) => {
             let ms = duration.as_secs() * 1000 + duration.subsec_nanos() as u64 / 1000000;
             let filename = file.unwrap_or("to stdout".to_owned());
-            printerr!("Wrote {} in {} ms", filename, ms);
+            eprintln!("Wrote {} in {} ms", filename, ms);
         },
         Err(e) => {
-            printerr!("{}", e);
+            eprintln!("{}", e);
             process::exit(1);
         },
     }

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -5,7 +5,6 @@ use getopts::Options;
 use std::path::{Path, PathBuf};
 use std::{error, fmt};
 use std::str::FromStr;
-use std::io::Write;
 use std;
 
 use self::SourceImages::*;
@@ -138,7 +137,7 @@ pub fn parse_args(args: &[String]) -> Result<Args, ArgsError> {
         match opt_str.as_str() {
             "reverse" | "rev" => modifiers.push(Modifier::Reverse),
             "shuffle" => modifiers.push(Modifier::Shuffle),
-            m @ _ => printerr!("Ignoring unknown modifier `{}`", m),
+            m @ _ => eprintln!("Ignoring unknown modifier `{}`", m),
         }
     }
 


### PR DESCRIPTION
Caveat: eprintln! panics when stderr isn't writeable, so this might break Windows compatibility. From what I can tell, the macro that was there also would fail similarly. Net benefit is using a built-in instead of rolling-your-own.